### PR TITLE
docker build -t rentx0 . && docker run -p 3000:3333 rentx0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:alpine
+
+WORKDIR /home/lab/dso/devsecops-teste/app1
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+COPY --chown=node:node . .
+USER node
+
+EXPOSE 3000
+
+CMD [ "npm", "run", "dev" ]


### PR DESCRIPTION
Iza fiz uma primeira versão do Dockerfile. Fiz baseado na instalação das dependências e no comando que pré-definido node run dev. 

**Build:**
docker build -t rentx0 . 

**Para executar:**
docker run -p 3000:3333 rentx0

Porém para "Dockernizar" em um cenário real,  teríamos que ajustar para algo que contemplasse a integração com o Banco. 
